### PR TITLE
Add vue to the references section of tsconfig.build.json

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -8,5 +8,8 @@
 		{
 			"path": "./plugins/tsconfig.build.json"
 		},
+		{
+			"path": "./vue/tsconfig.build.json"
+		}
 	]
 }


### PR DESCRIPTION
I added it because the code modification under vue (vuejs/language-tools) directory was not being built with `pnpm run watch`. If there are any issues, please close this Pull Request.